### PR TITLE
Usar links sem protocolo

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,9 +15,9 @@
             <link href="css/fontello-ie7.css" type="text/css" rel="stylesheet">
         <![endif]-->
     <!-- Google Web fonts -->
-    <link href='http://fonts.googleapis.com/css?family=Quattrocento:400,700' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Patua+One' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Quattrocento:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Patua+One' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <style>
       body {
@@ -26,7 +26,7 @@
     </style>
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-          <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+          <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
         <![endif]-->
     <!-- Favicon -->
     <link rel="shortcut icon" href="favicon.ico">
@@ -37,7 +37,7 @@
       });
     </script>
 
-        <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+        <script type="text/javascript" src="//www.google.com/jsapi"></script>
     <script type="text/javascript">
       google.load("visualization", "1", {packages:["corechart"]});
       google.setOnLoadCallback(drawChart);


### PR DESCRIPTION
Por questões de segurança, alguns browsers (inclusive o Chrome) bloqueiam recursos linkados via "http" por sites acessados via "https." O resultado disso, no site do donamaria, é que as fontes não são carregadas. Uma solução para este problema é utilizar links "com protocolo relativo." O browser resolverá o link utilizando o mesmo protocolo que o usuário utilizou para acessar o site.
